### PR TITLE
Naming fixes

### DIFF
--- a/src/components/widgets/EditionsNote.astro
+++ b/src/components/widgets/EditionsNote.astro
@@ -9,7 +9,7 @@ import { Icon } from 'astro-icon/components';
         name="tabler:alert-triangle"
         class="w-7 h-7 text-orange-600 inline-block align-text-bottom"
       /> Select Your Preferred Edition:</span
-    > Choose from a range of Desktop Environments, Wayland Compositors and Window Managers including KDE Plasma, GNOME, XFCE, i3, Wayfire, LXQt, Openbox,
+    > Choose from a range of Desktop Environments, Wayland Compositors and X11 Window Managers including KDE Plasma, GNOME, XFCE, i3, Wayfire, LXQt, Openbox,
     Cinnamon, COSMIC, UKUI, LXDE, Mate, Budgie, Qtile, Hyprland and Sway. Simply download and install
     using the online GUI ISO installer.
   </div>

--- a/src/components/widgets/EditionsNote.astro
+++ b/src/components/widgets/EditionsNote.astro
@@ -9,8 +9,8 @@ import { Icon } from 'astro-icon/components';
         name="tabler:alert-triangle"
         class="w-7 h-7 text-orange-600 inline-block align-text-bottom"
       /> Select Your Preferred Edition:</span
-    > Choose from a range of desktop environments including KDE, GNOME, XFCE, i3WM, Wayfire, LXQT, OpenBox,
-    Cinnamon, Cosmic, UKUI, LXDE, Mate, Budgie, Qtile, Hyprland and Sway. Simply download and install
+    > Choose from a range of Desktop Environments, Wayland Compositors and Window Managers including KDE Plasma, GNOME, XFCE, i3, Wayfire, LXQt, Openbox,
+    Cinnamon, COSMIC, UKUI, LXDE, Mate, Budgie, Qtile, Hyprland and Sway. Simply download and install
     using the online GUI ISO installer.
   </div>
 </section>

--- a/src/components/widgets/Features.astro
+++ b/src/components/widgets/Features.astro
@@ -10,7 +10,7 @@ const items = [
       icon: 'tabler:package',
     },
     {
-      title: 'Choose Your Ideal Desktop Environment',
+      title: 'Select Your Preferred Edition',
       description:
         'CachyOS offers a variety of popular Desktop Environments, Wayland Compositors and X11 Window Managers including KDE Plasma, GNOME, XFCE, i3, Wayfire, LXQt, Openbox, Cinnamon, COSMIC, UKUI, LXDE, Mate, Budgie, Qtile, Hyprland and Sway. Select your preferred environment during the online installation process.',
       icon: 'tabler:rocket',

--- a/src/components/widgets/Features.astro
+++ b/src/components/widgets/Features.astro
@@ -12,7 +12,7 @@ const items = [
     {
       title: 'Choose Your Ideal Desktop Environment',
       description:
-        'CachyOS offers a variety of popular desktop environments including KDE, GNOME, XFCE, i3WM, Wayfire, LXQT, OpenBox, Cinnamon, Cosmic, UKUI, LXDE, Mate, Budgie, Qtile, Hyprland and Sway. Select your preferred environment during the online installation process.',
+        'CachyOS offers a variety of popular Desktop Environments, Wayland Compositors and X11 Window Managers including KDE Plasma, GNOME, XFCE, i3, Wayfire, LXQt, Openbox, Cinnamon, COSMIC, UKUI, LXDE, Mate, Budgie, Qtile, Hyprland and Sway. Select your preferred environment during the online installation process.',
       icon: 'tabler:rocket',
     },
     {

--- a/src/content/post/2404-april-release.md
+++ b/src/content/post/2404-april-release.md
@@ -34,7 +34,7 @@ Here you can find more detailed changes for this release:
 
 **Bug-Fixes:**
 
-- Autologin: Fixed the autologin option when used together with sddm
+- Autologin: Fixed the autologin option when used together with SDDM
 - xz: Provide a patched xz package
 - libarchive: Mitigate commit from malicious xz actor
 - cachyos-settings: udev-rule: don't set watermark_scale_factor to 125, since it siginificantly increases RAM usage

--- a/src/content/post/2408-august-release.md
+++ b/src/content/post/2408-august-release.md
@@ -1,6 +1,6 @@
 ---
 title: CachyOS August 2024 Release
-excerpt: NVIDIA Open Module, Cosmic, Secure-Boot, Ally X, CDN
+excerpt: NVIDIA Open Module, COSMIC, Secure-Boot, Ally X, CDN
 category: release
 tags:
   - release
@@ -14,7 +14,7 @@ Starting with this release, the hardware detection will automatically use the op
 
 We've also included the latest NVIDIA Beta driver (560) after extensive testing. This driver appears to be in a stable state following its second beta release.
 
-The Cosmic Desktop Environment is now available for installation. We'll follow the upstream release (Alpha 1) for packaging. Packages based on the latest commit are available, though these won't be used for installation. Existing users can install Cosmic on their current setup with the command: `sudo pacman -S cosmic-session`. This installs the base packages for running Cosmic. Additional packages like cosmic-text-editor, cosmic-terminal, and cosmic-store are also available.
+The COSMIC Desktop Environment is now available for installation. We'll follow the upstream release (Alpha 1) for packaging. Packages based on the latest commit are available, though these won't be used for installation. Existing users can install COSMIC on their current setup with the command: `sudo pacman -S cosmic-session`. This installs the base packages for running COSMIC. Additional packages like cosmic-text-editor, cosmic-terminal, and cosmic-store are also available.
 
 Our infrastructure has seen significant improvements:
 We're proud to announce that CDN77 is sponsoring us with a worldwide cache CDN. This greatly enhances connection speeds for users, especially in regions we previously couldn't serve effectively with our existing mirrors. This CDN has been tested for about 3 weeks by us and the community, receiving positive feedback.
@@ -40,7 +40,7 @@ KWin's libei is now used for Wayland Input Emulation instead of libextest. Fixes
 **Features:**
 
 - chwd: NVIDIA now uses the open module as default for supported cards
-- Desktop: Added Cosmic Desktop Environment to the installation options
+- Desktop: Added COSMIC Desktop Environment to the installation options
 - NVIDIA: Latest 560 Beta driver is now the default; egl-wayland patched to fix crashes in Firefox and other applications
 - mirrors: CDN77 sponsored CachyOS with Object Storage featuring a worldwide cache, significantly improving connection speeds for users
 - mirrors: CachyOS now provides its own Arch Linux mirror to avoid syncing issues, set as default during installation along with fallback mirrors

--- a/src/content/post/2409-september-release.md
+++ b/src/content/post/2409-september-release.md
@@ -14,7 +14,7 @@ We have started to optimize more packages with PGO. In the case of LLVM and Clan
 
 The repository sync is now happening more often, which means there will be even less delay between the Arch repository and our optimized packages. Also, starting from 27.09.24, we are applying `-fno-semantic-interposition` automatically to -fpic compiled packages. This can significantly improve many shared packages. We have also started to replace `zlib` with `zlib-ng` and its compat layer. `zlib-ng` is a more modern alternative to `zlib`, which provides better performance and more modern techniques.
 
-The `cachyos-kde-settings` package now installs an sddm config, which enables Wayland by default for sddm. This has the benefit that refresh rates, resolution, and other settings can be applied to it, providing a better experience.
+The `cachyos-kde-settings` package now installs an SDDM config, which enables Wayland by default for SDDM. This has the benefit that refresh rates, resolution, and other settings can be applied to it, providing a better experience.
 GPUs that do not support Wayland (legacy NVIDIA) need to manually remove this config. We may introduce hardware detection integration for this in the future, but this has not been done yet.
 
 In `cachyos-settings`, we have added changes to the handling of NetworkManager. NetworkManager will now use systemd-resolved as the backend, which helps fix issues with download speed in Steam due to its massive DNS requests. Enabling DNS caching massively improves that. Also, we are now adding an NTP Server for systemd-timesyncd, which will default to time.google.com. There have been increased reports in Arch Linux, as well as CachyOS, that the timeservers provided as default are not working correctly. The previously used timeservers will still be used as fallbacks.
@@ -32,7 +32,7 @@ Together with this release the **old ISO** will **not work** anymore, due the ch
 - Repository: Starting from 27.09.2024, packages compiled with -fpic will automatically enable -fno-semantic-interposition. This can provide a performance improvement for many packages.
 - zlib-ng: Is now used as a replacement for zlib
 - Mirrors: New Mirror in Austria, hosted by Soulharsh007.
-- sddm: On the KDE Installation, sddm will now default to Wayland as the compositor. # Provide Migration changes in release post
+- SDDM: On the KDE Installation, SDDM will now default to Wayland as the compositor. # Provide Migration changes in release post
 - cachyos-settings: NetworkManager now uses systemd-resolved as the backend, which helps with DNS caching
 - cachyos-settings: Use time.google.com as the timesync server to avoid issues with timesync on some setups
 - gcc: Added fixes for the tuning of znver5

--- a/src/content/post/2410-october-release.md
+++ b/src/content/post/2410-october-release.md
@@ -1,6 +1,6 @@
 ---
 title: CachyOS October 2024 Release
-excerpt: amdgpu, chwd, sddm
+excerpt: amdgpu, chwd, SDDM
 category: release
 tags:
   - release
@@ -11,7 +11,7 @@ tags:
 This is our 11th release this year, which is intended as a fixing release.
 
 There has been an increased amount of reports, that people with RDNA3 and AMD iGPU's were not able to get a graphical session on the ISO, this has been fixed with adding xf86-video-amdgpu.
-Besides that there are some fixes for the sddm wayland session for KDE, which should be now fully resolved. There are some more fixes with the upcoming Plasma 6.2 release, which should make the experience better.
+Besides that there are some fixes for the SDDM wayland session for KDE, which should be now fully resolved. There are some more fixes with the upcoming Plasma 6.2 release, which should make the experience better.
 
 Also, we have fixed reinstalling profiles with our hardware detection, this helps if users are changing their hardware or want to reinstall the driver packages.
 
@@ -24,7 +24,7 @@ Besides that we had some common package updates, like the kernel, mesa, python a
 - Package Updates: linux-cachyos 6.11.1, mesa 24.2.4, scx-scheds 1.0.5, python 3.12.7
 
 **Bug Fixes:**
-- sddm: Pulled in newer sddm to fix wayland session logins
+- SDDM: Pulled in newer SDDM to fix wayland session logins
 - ISO: Added xf86-video-amdgpu to fix graphical session loading on some setups
 - chwd: Fixed reinstallation of profiles
 


### PR DESCRIPTION
Use correct stylization of project names.

Stop referring to Plasma as "KDE" instead of "Plasma" or "KDE Plasma" - https://kde.org/plasma-desktop/

Stop referring to i3 as "i3WM" - https://i3wm.org/

Since the list does not contain only DEs but also X11 WMs and Wayland compositors, refer to them as such.

Unified title for the same section across the two pages - it does not contain only DEs, and it's inconsistent between pages - https://cachyos.org/ | https://cachyos.org/download/ 