### PR TITLE
fix(grammar): improve verb phrasing

### DIFF
--- a/src/components/widgets/Features.astro
+++ b/src/components/widgets/Features.astro
@@ -6,7 +6,7 @@ const items = [
     {
       title: 'Enhance Your Performance with Optimized Packages',
       description:
-        'CachyOS does compile packages with the x86-64-v3, x86-64-v4 and Zen4 instruction set and LTO to provide a higher performance. Core packages also get PGO or BOLT optimization.',
+        'CachyOS compiles packages with the x86-64-v3, x86-64-v4 and Zen4 instruction set and LTO to provide a higher performance. Core packages also get PGO or BOLT optimization.',
       icon: 'tabler:package',
     },
     {


### PR DESCRIPTION
I just visited the CatchyOS website for the first time, and this grammar quirk in one of the first few paragraphs stuck out to me as suggesting the project's run by non-native-English speakers, which is entirely understandable but not the best first impression.

"does compile" isn't grammatically incorrect, per say, but it suggests a refutation to an argument (e.g. "CatchyOS *doesn't* compile packages with special instruction sets" or "CatchyOS doesn't perform any optimization") that didn't occur. Saying "compiles" is more natural in this context where you're just making a statement and not replying to someone or contrasting against something.