### PR TITLE
Issue #31 - Change Sourceforge to SourceForge in download menu's suno…

### DIFF
--- a/src/components/widgets/DropdownMenu.tsx
+++ b/src/components/widgets/DropdownMenu.tsx
@@ -80,7 +80,7 @@ const DropdownMenu = ({ data }: Props) => {
               href={data.srcforge_url}
               className="btn-dropdown-item block"
             >
-              Sourceforge
+              SourceForge
             </MenuItem>
           )}
           {data.magnet_url && (


### PR DESCRIPTION
Closes #31 

## Description

Changed 'Sourceforge` to `SourceForge` in download submenu

## Screenshots

<img width="387" height="405" alt="image" src="https://github.com/user-attachments/assets/d2d26f35-0c38-4523-a339-8c80dc77a2c5" />
