### PR TITLE
Update alert message in EditionsNote component

### DIFF
--- a/src/components/widgets/EditionsNote.astro
+++ b/src/components/widgets/EditionsNote.astro
@@ -8,7 +8,7 @@ import { Icon } from 'astro-icon/components';
       <Icon
         name="tabler:alert-triangle"
         class="w-7 h-7 text-orange-600 inline-block align-text-bottom"
-      /> All Desktop Environments Available:</span
+      /> Many Desktop Environments Available:</span
     > The online installer lets you choose from 17+ environments including KDE Plasma, GNOME, COSMIC,
     Hyprland, Sway, Niri, i3, XFCE, and more.
   </div>


### PR DESCRIPTION
Replace "All" with "Many" as it seemed to infer either every desktop environment was available, or that all were listed here, neither of these is the case.