### PR TITLE
Imprint: Change to legal notice

### DIFF
--- a/src/components/widgets/Footer.astro
+++ b/src/components/widgets/Footer.astro
@@ -1,7 +1,7 @@
 ---
 import { Icon } from 'astro-icon/components';
 import { getHomePermalink, getAsset } from '~/utils/permalinks';
-import ImprintButton from './ImprintButton';
+import LegalNoticeButton from './LegalNoticeButton';
 
 const links = [
   {
@@ -60,7 +60,7 @@ const social = [
             class="text-muted hover:text-gray-700 dark:text-gray-400 hover:underline transition duration-150 ease-in-out mr-2 rtl:mr-0 rtl:ml-2"
             href="https://wiki.cachyos.org/policy/privacy_policy/">Privacy Policy</a
           >
-          <ImprintButton client:load />
+          <LegalNoticeButton client:load />
         </div>
       </div>
       {

--- a/src/components/widgets/LegalNoticeButton.tsx
+++ b/src/components/widgets/LegalNoticeButton.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
-import ImprintModal from './ImprintModal';
+import LegalNoticeModal from './LegalNoticeModal';
 
-export default function ImprintButton() {
+export default function LegalNoticeButton() {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <>
-      <ImprintModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      <LegalNoticeModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
       <button
         className="text-muted hover:text-gray-700 dark:text-gray-400 hover:underline transition duration-150 ease-in-out mr-2 rtl:mr-0 rtl:ml-2"
         onClick={() => setIsOpen(true)}
       >
-        Imprint
+        Legal Notice
       </button>
     </>
   );

--- a/src/components/widgets/LegalNoticeModal.tsx
+++ b/src/components/widgets/LegalNoticeModal.tsx
@@ -1,7 +1,7 @@
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from '@headlessui/react';
 import { Fragment } from 'react';
 
-const ImprintModal = ({ isOpen, onClose }: Readonly<{ isOpen: boolean; onClose: () => void }>) => {
+const LegalNoticeModal = ({ isOpen, onClose }: Readonly<{ isOpen: boolean; onClose: () => void }>) => {
   return (
     <Transition appear show={isOpen} as={Fragment}>
       <Dialog as="div" className="relative z-10" onClose={onClose}>
@@ -53,7 +53,7 @@ const ImprintModal = ({ isOpen, onClose }: Readonly<{ isOpen: boolean; onClose: 
                   as="h3"
                   className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-200 text-center"
                 >
-                  Imprint
+                  Legal Notice
                 </DialogTitle>
                 <div className="mt-2 space-y-0.5">
                   <p>Peter Jung</p>
@@ -83,4 +83,4 @@ const ImprintModal = ({ isOpen, onClose }: Readonly<{ isOpen: boolean; onClose: 
   );
 };
 
-export default ImprintModal;
+export default LegalNoticeModal;


### PR DESCRIPTION
Imprint is correct for german and EU, but internationally there should be Legal Notice used.

See: https://www.e-recht24.de/impressum/13120-impressum-auf-englisch-fuer-ihre-website.html