### PR TITLE
Update Hero.astro to correctly reflect the current standard scheduler

### DIFF
--- a/src/components/widgets/Hero.astro
+++ b/src/components/widgets/Hero.astro
@@ -19,7 +19,7 @@ import heroDark from '~/assets/images/hero_dark.png';
         <p class="mt-6 max-w-3xl text-lg text-gray-600 mb-8 text-center mx-auto dark:text-gray-300">
           <span class="font-semibold text-primary-700 dark:text-primary-300">CachyOS</span> ships every
           package optimized for your CPU - compiled with x86-64-v3/v4 and Zen4 instructions, LTO, and
-          PGO - on top of a custom kernel with the tuned EEVDF scheduler. The result: a noticeably faster
+          PGO - on top of a custom kernel with the tuned BORE scheduler. The result: a noticeably faster
           Arch Linux experience with the same rolling-release flexibility you expect.
         </p>
         <div


### PR DESCRIPTION
Changed EEVDF to BORE in Hero.astro, to correctly reflect the current standard scheduler.