### PR TITLE
fix: remove unnecessary cursor pointer

### DIFF
--- a/src/components/widgets/Editions.astro
+++ b/src/components/widgets/Editions.astro
@@ -104,7 +104,7 @@ const items = [
                 {preview && (
                   <Image
                     src={preview}
-                    class="transform lg:hover:-translate-x-8 rounded-xl transition ease-in-out duration-700 cursor-pointer"
+                    class="transform lg:hover:-translate-x-8 rounded-xl transition ease-in-out duration-700"
                     alt={`${title} preview`}
                     decoding="async"
                     loading="lazy"


### PR DESCRIPTION
Forgot to remove this when I was experimenting with opening image on click.