### PR TITLE
fix: improve responsive layout

### DIFF
--- a/src/components/widgets/AboutDistribution.astro
+++ b/src/components/widgets/AboutDistribution.astro
@@ -2,23 +2,21 @@
 
 ---
 
-<section class="py-28 overflow-hidden" id="distribution">
+<section class="py-26 lg:py-28 overflow-hidden" id="distribution">
   <div class="max-w-4xl mx-auto px-4 sm:px-6">
-    <div>
-      <div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">
-        <h3
-          class="mb-20 text-2xl md:text-4xl xl:text-6xl text-center font-bold font-heading tracking-px-n leading-none"
-        >
-          About the Distribution
-        </h3>
-        <div class="max-w-3xl mx-auto">
-          <p class="text-lg text-gray-600 mb-8 text-center mx-auto dark:text-gray-400">
-            <span class="font-semibold text-primary-700 dark:text-primary-300">CachyOS</span> is a performance-focused
-            Arch Linux distribution that rebuilds packages with modern CPU optimizations, ships a custom-tuned
-            kernel, and provides a polished installation experience. Built for users who want Arch's rolling-release
-            model with measurable speed improvements out of the box.
-          </p>
-        </div>
+    <div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">
+      <h3
+        class="mb-20 text-4xl md:text-5xl xl:text-6xl text-center font-bold font-heading tracking-px-n leading-none"
+      >
+        About the Distribution
+      </h3>
+      <div class="max-w-3xl mx-auto">
+        <p class="text-lg text-gray-600 mb-8 text-center mx-auto dark:text-gray-400">
+          <span class="font-semibold text-primary-700 dark:text-primary-300">CachyOS</span> is a performance-focused
+          Arch Linux distribution that rebuilds packages with modern CPU optimizations, ships a custom-tuned
+          kernel, and provides a polished installation experience. Built for users who want Arch's rolling-release
+          model with measurable speed improvements out of the box.
+        </p>
       </div>
     </div>
   </div>

--- a/src/components/widgets/Editions.astro
+++ b/src/components/widgets/Editions.astro
@@ -64,7 +64,7 @@ const items = [
 ---
 
 <section class="pt-12 md:pt-24 pb-20 md:pb-52">
-  <div class="container mx-auto grid gap-12 md:gap-18 px-6 space-y-20 md:space-y-52">
+  <div class="mx-auto max-w-6xl grid gap-12 md:gap-18 px-3 md:px-6 space-y-20 md:space-y-52">
     {
       items.map((subitems) =>
         subitems.map(
@@ -104,7 +104,7 @@ const items = [
                 {preview && (
                   <Image
                     src={preview}
-                    class="transform lg:hover:-translate-x-8 rounded-xl transition ease-in-out duration-700 cursor-pointer"
+                    class="transform lg:hover:-translate-x-8 rounded-xl transition ease-in-out duration-700"
                     alt={`${title} preview`}
                     decoding="async"
                     loading="lazy"

--- a/src/components/widgets/Editions.astro
+++ b/src/components/widgets/Editions.astro
@@ -3,6 +3,8 @@ import { Image } from 'astro:assets';
 import DropdownMenu from '~/components/widgets/DropdownMenu';
 import { ISOEdition, ISOSource, generateDownloadLink } from '~/utils/utils';
 import versions from '~/versions';
+import desktopImage from '~/assets/images/desktop_dark.png';
+import handheldImage from '~/assets/images/handheld.png';
 
 const [desktop_magnet = '', handheld_magnet = ''] = await Promise.all(
   [
@@ -36,7 +38,7 @@ const items = [
         versions.desktopISOVersion,
         ISOSource.TORRENT
       ),
-      preview: import('~/assets/images/desktop_dark.png'),
+      preview: desktopImage,
     },
     {
       title: 'Handheld Edition',
@@ -57,7 +59,7 @@ const items = [
         versions.handheldISOVersion,
         ISOSource.TORRENT
       ),
-      preview: import('~/assets/images/handheld.png'),
+      preview: handheldImage,
     },
   ],
 ];

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -20,7 +20,7 @@ const navItems = [
   class="sticky top-0 z-40 flex-none mx-auto transition-colors w-full duration-500 lg:z-50 supports-backdrop-blur:bg-white/95 md:backdrop-blur-xs"
   id="header"
 >
-  <div class="py-3 px-3 mx-auto w-full md:justify-between max-w-6xl md:px-4">
+  <div class="py-3 px-3 mx-auto w-full md:justify-between max-w-6xl md:px-6">
     <div
       class="md:flex md:items-center md:justify-between text-gray-700 font-semibold text-sm leading-6 dark:text-gray-200"
     >

--- a/src/components/widgets/Sponsors.astro
+++ b/src/components/widgets/Sponsors.astro
@@ -34,7 +34,7 @@ const sponsors = [
 ---
 
 <section class="py-20">
-  <div class="container px-4 mx-auto">
+  <div class="max-w-6xl px-4 mx-auto">
     <div class="max-w-xl mx-auto mb-20 text-center">
       <h2 class="mt-8 text-5xl lg:text-6xl font-bold font-heading">Our Sponsors</h2>
     </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,7 +14,7 @@ const { meta = {} } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en" class="2xl:text-[20px]">
+<html lang="en" class="2xl:text-xl">
   <head>
     <MetaTags {...meta} />
   </head>

--- a/src/pages/[...blog]/[...page].astro
+++ b/src/pages/[...blog]/[...page].astro
@@ -26,7 +26,7 @@ const meta = {
 ---
 
 <Layout {meta}>
-  <section class="px-6 sm:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl">
+  <section class="px-6 sm:px-6 py-18 lg:py-28 mx-auto max-w-4xl">
     <BackgroundGradient position="right" rotate="rotate-35" />
     <Headline> Cachy Blog </Headline>
     <BlogList posts={page.data} />


### PR DESCRIPTION
See https://github.com/CachyOS/website/issues/49#issuecomment-4336424360

I removed `container` classes to avoid "jumping" between breakpoints and instead used a static max-width. Some additional minor cleanup for top padding in about/blog pages.