### PR TITLE
fix: add cursor styles to interactive elements

### DIFF
--- a/src/components/common/ToggleTheme.astro
+++ b/src/components/common/ToggleTheme.astro
@@ -13,7 +13,7 @@ export interface Props {
 const {
   label = 'Toggle between Dark and Light mode',
   class:
-    className = 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center',
+    className = 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center cursor-pointer',
   iconClass = 'w-6 h-6',
   iconName = 'tabler:sun',
 } = Astro.props;

--- a/src/components/widgets/SupportModal.tsx
+++ b/src/components/widgets/SupportModal.tsx
@@ -57,7 +57,7 @@ const SupportModal = ({ isOpen, onClose }: Readonly<{ isOpen: boolean; onClose: 
                 <div className="absolute right-0 top-0 mt-2 mr-2">
                   <button
                     aria-label="Close"
-                    className="btn btn-icon"
+                    className="btn btn-icon cursor-pointer"
                     onClick={onClose}
                     type="button"
                     autoFocus={false}
@@ -118,7 +118,7 @@ const SupportRow = ({ label, text, mode }: Readonly<SupportOption>) => {
       ) : (
         <button
           type="button"
-          className="btn btn-icon"
+          className="btn btn-icon cursor-copy"
           onClick={() => copyToClipboard(text)}
           aria-label={`Copy ${label} address to clipboard`}
         >

--- a/src/components/widgets/SupportOptions.tsx
+++ b/src/components/widgets/SupportOptions.tsx
@@ -10,7 +10,7 @@ const SupportOptions = ({ children }: Readonly<Props>) => {
   return (
     <>
       <SupportModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
-      <button className="btn" onClick={() => setIsOpen(true)}>
+      <button className="btn cursor-pointer" onClick={() => setIsOpen(true)}>
         {children}
       </button>
     </>


### PR DESCRIPTION
## Summary
- Add `cursor-pointer` to theme toggle and support buttons
- Add `cursor-copy` to copy buttons in support modal
